### PR TITLE
Replace npm with Yarn in Deploy Workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,15 +23,14 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Run tests
-        run: npm test
+        run: yarn test
 
       - name: Build static site
         run: |
-          npm run build
-          npx next export
+          yarn run build
 
       - name: Sync to S3
         run: |


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy.yml` to standardize the use of `yarn` instead of `npm` for dependency management, testing, and building the static site.