### PR TITLE
Use Next Public Environment Variable and Explicitly Send ReactGA Event

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,37 +1,39 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import ReactGA from "react-ga4";
+import ReactGA from 'react-ga4';
 import Terminal from '@/components/Terminal/Terminal';
 import { Ubuntu_Mono } from 'next/font/google';
 
-const gaId = process.env.GA_MEASUREMENT_ID;
+const gaId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+
 if (gaId) {
   ReactGA.initialize(gaId);
 } else {
-  console.warn("Google Analytics measurement ID is missing");
+  console.warn('Google Analytics measurement ID is missing');
 }
 
-const ubuntuMono = Ubuntu_Mono({
-  weight: '400',
-  subsets: ['latin'],
-})
+const ubuntuMono = Ubuntu_Mono({ weight: '400', subsets: ['latin'] });
 
 export default function App() {
-
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
     setIsLoaded(true);
   }, []);
 
-  return (
-    isLoaded ? (
-      <div id="container" className={ubuntuMono.className}>
-        <Terminal />
-      </div>
-    ) : (
-      null
-    )
-  );
+  useEffect(() => {
+    if (!gaId) return;
+    ReactGA.send({
+      hitType: 'pageview',
+      page: window.location.pathname,
+      title: document.title,
+    });
+  }, []);
+
+  return isLoaded ? (
+    <div id="container" className={ubuntuMono.className}>
+      <Terminal />
+    </div>
+  ) : null;
 }


### PR DESCRIPTION
## Description

This pull request updates the Google Analytics integration and refines the initialization logic in the `src/app/page.tsx` file. The most important changes include switching to the correct environment variable for the GA measurement ID and ensuring pageview events are sent when the app loads.

**Google Analytics Integration Updates:**

* Changed the environment variable from `GA_MEASUREMENT_ID` to `NEXT_PUBLIC_GA_MEASUREMENT_ID` for compatibility with Next.js public environment variables.
* Added a `useEffect` hook to send a pageview event to Google Analytics when the app loads, improving tracking accuracy.

**Code Style and Initialization Improvements:**

* Updated code style for consistency (single quotes, compact object initialization).
* Simplified the conditional rendering logic for the main app component.